### PR TITLE
Extract block height from proof

### DIFF
--- a/eth-custodian/contracts/BlockHeightFromProofExtractor.sol
+++ b/eth-custodian/contracts/BlockHeightFromProofExtractor.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8;
+
+import "rainbow-bridge-sol/nearbridge/contracts/Borsh.sol";
+
+library BlockHeightFromProofExtractor {
+    using Borsh for Borsh.Data;
+    using BlockHeightFromProofExtractor for Borsh.Data;
+
+    function skipNBytes(Borsh.Data memory data, uint skipBytesCount) internal pure {
+        data.requireSpace(skipBytesCount);
+        unchecked {
+            data.ptr += skipBytesCount;
+        }
+    }
+
+    function skipArray(Borsh.Data memory data, uint32 itemSizeInBytes) internal pure {
+        uint32 itemsCount = data.decodeU32();
+        uint32 skipBytesCount = itemsCount * itemSizeInBytes;
+
+        data.skipNBytes(skipBytesCount);
+    }
+
+    function skipBytesArray(Borsh.Data memory data) internal pure {
+        uint32 itemCount = data.decodeU32();
+        for (uint32 i = 0; i < itemCount; i++) {
+            data.skipBytes();
+        }
+    }
+
+    function skipMerklePath(Borsh.Data memory data) internal pure {
+        uint32 MerklePathItemSize = 32 + 1;
+        data.skipArray(MerklePathItemSize);
+    }
+
+    function skipExecutionStatus(Borsh.Data memory data) internal pure {
+        uint8 enumIndex = data.decodeU8();
+        if (enumIndex == 2) {
+            data.skipBytes();
+        } else if (enumIndex == 3) {
+            data.skipNBytes(32);
+        }
+    }
+
+    function skipExecutionOutcomeWithIdAndProof(Borsh.Data memory data) internal pure  {
+        data.skipMerklePath();
+        data.skipNBytes(32 + 32);
+        data.skipBytesArray();
+        data.skipArray(32);
+        data.skipNBytes(8 + 16);
+        data.skipBytes();
+        data.skipExecutionStatus();
+    }
+
+    function getBlockHeightFromProof(bytes calldata proofData) internal pure returns(uint64) {
+        Borsh.Data memory data = Borsh.from(proofData);
+
+        data.skipExecutionOutcomeWithIdAndProof();
+        data.skipMerklePath();
+        data.skipNBytes(32 + 32);
+
+        return data.decodeU64();
+    }
+}

--- a/eth-custodian/contracts/BlockHeightFromProofExtractor.sol
+++ b/eth-custodian/contracts/BlockHeightFromProofExtractor.sol
@@ -43,20 +43,37 @@ library BlockHeightFromProofExtractor {
     }
 
     function skipExecutionOutcomeWithIdAndProof(Borsh.Data memory data) internal pure  {
+        //proof
         data.skipMerklePath();
+
+        //block_hash(bytes32) + outcome.id(bytes32)
         data.skipNBytes(32 + 32);
+
+        //logs
         data.skipBytesArray();
+
+        //receipt_ids(bytes32[])
         data.skipArray(32);
+
+        //gas_burnt(uint64) + tokens_burnt(uint128)
         data.skipNBytes(8 + 16);
+
+        //executor_id
         data.skipBytes();
+
         data.skipExecutionStatus();
     }
 
     function getBlockHeightFromProof(bytes calldata proofData) internal pure returns(uint64) {
         Borsh.Data memory data = Borsh.from(proofData);
 
+        //outcome_proof
         data.skipExecutionOutcomeWithIdAndProof();
+
+        //outcome_root_proof
         data.skipMerklePath();
+
+        // prev_block_hash(bytes32) + inner_rest_hash(bytes32)
         data.skipNBytes(32 + 32);
 
         return data.decodeU64();

--- a/eth-custodian/contracts/EthCustodianProxy.sol
+++ b/eth-custodian/contracts/EthCustodianProxy.sol
@@ -100,7 +100,7 @@ contract EthCustodianProxy is
         bytes calldata proofData,
         uint64 proofBlockHeight
     ) external {
-        if (proofBlockHeight > migrationBlockHeight) {
+        if (getBlockHeightFromProof(proofData) > migrationBlockHeight) {
             _requireNotPaused(PAUSED_WITHDRAW_POST_MIGRATION);
             ethCustodianImpl.withdraw(proofData, proofBlockHeight);
         } else {
@@ -197,7 +197,7 @@ contract EthCustodianProxy is
         skipExecutionStatus(data);
     }
 
-    function getBlockHeightFromProof(bytes calldata proofData) external pure returns(uint64) {
+    function getBlockHeightFromProof(bytes calldata proofData) public pure returns(uint64) {
         Borsh.Data memory data = Borsh.from(proofData);
 
         skipExecutionOutcomeWithIdAndProof(data);

--- a/eth-custodian/contracts/EthCustodianProxy.sol
+++ b/eth-custodian/contracts/EthCustodianProxy.sol
@@ -94,6 +94,16 @@ contract EthCustodianProxy is
         );
     }
 
+    /// Withdraws the appropriate amount of ETH which is encoded in `proofData`
+    /// * `proofData` -- this is the proof that a tokens were burned on Near.
+    /// * `proofBlockHeight` -- this is the block height relative to which the proof is constructed.
+    ///                         Note that the height of this block can be significantly different
+    ///                         from the block number in which the tokens were burned on Near.
+    /// * `checkPreMigration` -- if set to true, the block height at which the tokens were burned on Near
+    ///                         will be extracted from proofData, and if it occurred before the migration,
+    ///                         the proofProducer will be updated accordingly.
+    ///                         If you are sure that the tokens were burned after the migration,
+    ///                         set this value to false to optimize gas consumption.
     function withdraw(
         bytes calldata proofData,
         uint64 proofBlockHeight,

--- a/eth-custodian/contracts/EthCustodianProxy.sol
+++ b/eth-custodian/contracts/EthCustodianProxy.sol
@@ -204,7 +204,6 @@ contract EthCustodianProxy is
         skipMerklePath(data);
         skipNBytes(data, 32 + 32);
 
-        skipNBytes(data, 208);
         uint64 height = data.decodeU64();
         return height;
     }

--- a/eth-custodian/test/EthCustodianProxy.js
+++ b/eth-custodian/test/EthCustodianProxy.js
@@ -144,7 +144,7 @@ describe('EthCustodianProxy contract', () => {
             await ethCustodianProxy.pauseProxy(PAUSED_WITHDRAW_POST_MIGRATION);
             const proof = require('./proof_template_from_testnet.json');
 
-            await expect(ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), blockHeightFromProof + 1))
+            await expect(ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), blockHeightFromProof + 1, true))
                 .to.be.revertedWith('Pausable: paused');
         });
 
@@ -153,7 +153,7 @@ describe('EthCustodianProxy contract', () => {
             await ethCustodianProxy.pauseProxy(PAUSED_WITHDRAW_PRE_MIGRATION);
             const proof = require('./proof_template_from_testnet.json');
 
-            await expect(ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), blockHeightFromProof))
+            await expect(ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), blockHeightFromProof, true))
                 .to.be.revertedWith('Pausable: paused');
         });
 
@@ -169,10 +169,10 @@ describe('EthCustodianProxy contract', () => {
 
             const proof = require('./proof_template_from_testnet.json');
 
-            await expect(ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), 1099))
+            await expect(ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), 1099, true))
                 .to.be.revertedWith('Pausable: paused');
 
-            await expect(ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), blockHeightFromProof + 1))
+            await expect(ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), blockHeightFromProof + 1, true))
                 .to.be.revertedWith('Pausable: paused');
         });
     });
@@ -234,7 +234,7 @@ describe('EthCustodianProxy contract', () => {
                 await ethers.provider.getBalance(user2.address));
 
             await expect(
-                ethCustodianProxy.withdraw(borshifyOutcomeProof(postMigrationProof), blockHeightFromProof + 1)
+                ethCustodianProxy.withdraw(borshifyOutcomeProof(postMigrationProof), blockHeightFromProof + 1, true)
             )
                 .to.emit(ethCustodian, 'Withdrawn')
                 .withArgs(user2.address, amount);
@@ -252,7 +252,7 @@ describe('EthCustodianProxy contract', () => {
             const balanceBefore = BigInt(await ethers.provider.getBalance(user2.address));
 
             await expect(
-                ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), blockHeightFromProof + 2)
+                ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), blockHeightFromProof + 2, true)
             )
                 .to.emit(ethCustodian, 'Withdrawn')
                 .withArgs(user2.address, amount);
@@ -268,7 +268,7 @@ describe('EthCustodianProxy contract', () => {
             const balanceBefore = BigInt(await ethers.provider.getBalance(user2.address));
 
             await expect(
-                ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), blockHeightFromProof)
+                ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), blockHeightFromProof, true)
             )
                 .to.emit(ethCustodian, 'Withdrawn')
                 .withArgs(user2.address, amount);
@@ -286,7 +286,7 @@ describe('EthCustodianProxy contract', () => {
             const migrationBlock = await ethCustodianProxy.migrationBlockHeight();
 
             await expect(
-                ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), parseInt(migrationBlock))
+                ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), parseInt(migrationBlock), true)
             )
                 .to.emit(ethCustodian, 'Withdrawn')
                 .withArgs(user2.address, amount);

--- a/eth-custodian/test/EthCustodianProxy.js
+++ b/eth-custodian/test/EthCustodianProxy.js
@@ -198,12 +198,12 @@ describe('EthCustodianProxy contract', () => {
 
             await expect(ethCustodianProxy.migrateToNewProofProducer(newProofProducerData, blockHeightFromProof))
                 .to.be.revertedWithCustomError(ethCustodianProxy, 'AlreadyMigrated');
+        });
 
         it('Should fail when block producer id is too long', async () => {
-            await expect(
-                ethCustodianProxy.migrateToNewProofProducer(Buffer.from('new-loooooooong-producer.testnet'), blockHeightFromProof)
-            )
-                .to.be.revertedWithCustomError(ethCustodianProxy, 'ProducerAccountIdTooLong');
+                await expect(
+                    ethCustodianProxy.migrateToNewProofProducer(Buffer.from('new-loooooooong-producer.testnet'), blockHeightFromProof)
+                ).to.be.revertedWithCustomError(ethCustodianProxy, 'ProducerAccountIdTooLong');
         });
     });
 

--- a/eth-custodian/test/EthCustodianProxy.js
+++ b/eth-custodian/test/EthCustodianProxy.js
@@ -156,6 +156,13 @@ describe('EthCustodianProxy contract', () => {
                 .to.be.revertedWith('Pausable: paused');
         });
 
+        it('Check block height', async () => {
+            await ethCustodianProxy.migrateToNewProofProducer(newProofProducerData, migrationBlock);
+            const proof = require('./proof_template_from_testnet.json');
+
+            await expect(await ethCustodianProxy.getBlockHeightFromProof(borshifyOutcomeProof(proof))).to.equal(39884271);
+        })
+
         it('Should pause all', async () => {
             await ethCustodianProxy.migrateToNewProofProducer(newProofProducerData, migrationBlock);
             await ethCustodianProxy.pauseAll();

--- a/eth-custodian/test/EthCustodianProxy.js
+++ b/eth-custodian/test/EthCustodianProxy.js
@@ -249,7 +249,7 @@ describe('EthCustodianProxy contract', () => {
 
         it('Should successfully withdraw and emit the event pre-migration with post-migration block height', async () => {
             await ethCustodianProxy.migrateToNewProofProducer(newProofProducerData, blockHeightFromProof + 1);
-            const balanceBefore = ethers.BigNumber.from(await ethers.provider.getBalance(user2.address));
+            const balanceBefore = BigInt(await ethers.provider.getBalance(user2.address));
 
             await expect(
                 ethCustodianProxy.withdraw(borshifyOutcomeProof(proof), blockHeightFromProof + 2)
@@ -257,8 +257,8 @@ describe('EthCustodianProxy contract', () => {
                 .to.emit(ethCustodian, 'Withdrawn')
                 .withArgs(user2.address, amount);
 
-            const balanceAfter = ethers.BigNumber.from(await ethers.provider.getBalance(user2.address));
-            const balanceDiff = balanceAfter.sub(balanceBefore);
+            const balanceAfter = BigInt(await ethers.provider.getBalance(user2.address));
+            const balanceDiff = balanceAfter - balanceBefore;
 
             expect(balanceDiff).to.equal(amount)
         });


### PR DESCRIPTION
* Supported extraction of the block number related to the given receipt from the proof.
* Fixed the check in withdraw. Now, when checking if the event occurred before the migration, the block number is extracted from the proof.
* For gas consumption optimization, added the flag checkPreMigration. The check and replacement of proofProducer are performed only if this flag is set to true.